### PR TITLE
Add unit tests for JsonUtils

### DIFF
--- a/src/test/java/io/json/compare/util/JsonUtilsTest.java
+++ b/src/test/java/io/json/compare/util/JsonUtilsTest.java
@@ -20,6 +20,12 @@ public class JsonUtilsTest {
     }
 
     @Test
+    public void toJsonWithJsonNodeReturnsSameInstance() throws IOException {
+        com.fasterxml.jackson.databind.JsonNode node = JsonUtils.toJson("{\"x\":42}");
+        assertSame(node, JsonUtils.toJson(node));
+    }
+
+    @Test
     public void convertObjectToJson() throws IOException {
         Map<String, Integer> map = new HashMap<>();
         map.put("a", 2);


### PR DESCRIPTION
Additive unit tests for `JsonUtils` — edge cases and current behavior pinned with explicit assertions. No existing test or production code changed.

Verified green under Java 17 (`mvn -pl . test -Dtest=JsonUtilsTest` → Tests run: 5, Failures: 0, Errors: 0).
